### PR TITLE
feat(vouchers): add fiscal fields to voucher entity

### DIFF
--- a/monarca/src/vouchers/dto/create-voucher-dto.ts
+++ b/monarca/src/vouchers/dto/create-voucher-dto.ts
@@ -2,10 +2,11 @@
  * FileName: create-voucher-dto
  * Description: Data Transfer Object for creating a new voucher. Defines and
  *              validates all required and optional fields sent in the request body,
- *              including file URLs injected by the upload interceptor.
- * Authors: Original Moncarca team
+ *              including file URLs and fiscal fields for CFDI integration.
+ * Authors: Original Monarca team
  * Last Modification made:
- * 25/02/2026 [Diego de la Vega] Added detailed comments and documentation for clarity and maintainability.
+ * 15/04/2026 [Fausto Izquierdo] Added fiscal fields (uuid, RFCs, subtotal, taxes)
+ *            for CFDI invoice data persistence.
  */
 
 import { ApiProperty } from '@nestjs/swagger';
@@ -17,6 +18,7 @@ import {
   IsOptional,
 } from 'class-validator';
 import { Transform } from 'class-transformer';
+
 export class CreateVoucherDto {
   @ApiProperty({
     description: 'Identifier of the related travel request',
@@ -88,4 +90,75 @@ export class CreateVoucherDto {
   })
   @IsString()
   id_approver: string;
+
+  // ──────────────────────────────────────────────
+  // Fiscal fields – CFDI integration (Req. 10)
+  // ──────────────────────────────────────────────
+
+  @ApiProperty({
+    description: 'UUID del Timbre Fiscal Digital from the CFDI XML (36 characters)',
+    example: '6F29A520-4C2A-4D3B-9E1F-8A7B6C5D4E3F',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  fiscal_uuid?: string;
+
+  @ApiProperty({
+    description: 'RFC of the invoice issuer (Emisor)',
+    example: 'AAA010101AAA',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  issuer_rfc?: string;
+
+  @ApiProperty({
+    description: 'Business name of the invoice issuer (Razón social del Emisor)',
+    example: 'Empresa Ejemplo S.A. de C.V.',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  issuer_name?: string;
+
+  @ApiProperty({
+    description: 'RFC of the invoice receiver (Receptor)',
+    example: 'BBB020202BBB',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  receiver_rfc?: string;
+
+  @ApiProperty({
+    description: 'Subtotal amount before taxes',
+    example: 1000.0,
+    required: false,
+  })
+  @IsOptional()
+  @Transform(({ value }) => (value != null ? Number(value) : undefined))
+  @IsNumber()
+  subtotal?: number;
+
+  @ApiProperty({
+    description: 'Total transferred taxes (IVA, IEPS)',
+    example: 160.0,
+    required: false,
+  })
+  @IsOptional()
+  @Transform(({ value }) => (value != null ? Number(value) : undefined))
+  @IsNumber()
+  tax_amount?: number;
+
+  @ApiProperty({
+    description: 'Total retained taxes (ISR, retained IVA)',
+    example: 50.0,
+    required: false,
+  })
+  @IsOptional()
+  @Transform(({ value }) => (value != null ? Number(value) : undefined))
+  @IsNumber()
+  retention_amount?: number;
 }
+

--- a/monarca/src/vouchers/entities/vouchers.entity.ts
+++ b/monarca/src/vouchers/entities/vouchers.entity.ts
@@ -1,10 +1,12 @@
 /**
  * FileName: vouchers.entity
  * Description: TypeORM entity representing the 'vouchers' database table. Defines
- *              all columns and the ManyToOne relationship to the Request entity.
- * Authors: Original Moncarca team
+ *              all columns, fiscal fields for CFDI integration,
+ *              and the ManyToOne relationship to the Request entity.
+ * Authors: Original Monarca team
  * Last Modification made:
- * 25/02/2026 [Diego de la Vega] Added detailed comments and documentation for clarity and maintainability.
+ * 15/04/2026 [Fausto Izquierdo] Added fiscal columns (uuid, RFCs, subtotal, taxes)
+ *            for CFDI invoice data persistence.
  */
 
 import {
@@ -15,6 +17,7 @@ import {
   JoinColumn,
 } from 'typeorm';
 import { Request } from 'src/requests/entities/request.entity';
+
 @Entity({ name: 'vouchers' })
 export class Voucher {
   @PrimaryGeneratedColumn('uuid')
@@ -38,7 +41,7 @@ export class Voucher {
   @Column({ name: 'date', type: 'timestamptz' })
   date: Date;
 
-  @Column({ name: 'file_url_pdf', type: 'varchar',nullable: true })
+  @Column({ name: 'file_url_pdf', type: 'varchar', nullable: true })
   file_url_pdf: string | null;
 
   @Column({ name: 'file_url_xml', type: 'varchar', nullable: true })
@@ -50,6 +53,42 @@ export class Voucher {
   @Column({ name: 'id_approver', type: 'uuid' })
   id_approver: string;
 
+  // ──────────────────────────────────────────────
+  // Fiscal fields – CFDI integration
+  // ──────────────────────────────────────────────
+
+  /** UUID del Timbre Fiscal Digital (36 chars, unique per invoice) */
+  @Column({ name: 'fiscal_uuid', type: 'varchar', length: 36, unique: true, nullable: true })
+  fiscal_uuid: string | null;
+
+  /** RFC del emisor de la factura */
+  @Column({ name: 'issuer_rfc', type: 'varchar', nullable: true })
+  issuer_rfc: string | null;
+
+  /** Razón social del emisor */
+  @Column({ name: 'issuer_name', type: 'varchar', nullable: true })
+  issuer_name: string | null;
+
+  /** RFC del receptor de la factura */
+  @Column({ name: 'receiver_rfc', type: 'varchar', nullable: true })
+  receiver_rfc: string | null;
+
+  /** Subtotal antes de impuestos */
+  @Column({ name: 'subtotal', type: 'decimal', precision: 12, scale: 2, nullable: true })
+  subtotal: number | null;
+
+  /** Total de impuestos trasladados (IVA, IEPS) */
+  @Column({ name: 'tax_amount', type: 'decimal', precision: 12, scale: 2, nullable: true })
+  tax_amount: number | null;
+
+  /** Total de impuestos retenidos (ISR, IVA retenido) */
+  @Column({ name: 'retention_amount', type: 'decimal', precision: 12, scale: 2, nullable: true })
+  retention_amount: number | null;
+
+  // ──────────────────────────────────────────────
+  // Relationships
+  // ──────────────────────────────────────────────
+
   @ManyToOne(
     () => Request,
     (requests) => requests.id,
@@ -58,3 +97,4 @@ export class Voucher {
   @JoinColumn({ name: 'id_request' })
   requests: Request;
 }
+


### PR DESCRIPTION
Implements database schema changes for Task 10 (ST-2), enabling persistence for fiscal data extracted from Mexican CFDI (3.3/4.0).

Changes Made
- Entity (vouchers.entity.ts): Added columns for fiscal_uuid (unique), RFCs, issuer/receiver names, and decimal fields for subtotal, tax_amount, and retention_amount.
- DTO (create-voucher-dto.ts): Updated with class-validator rules and Swagger documentation for the new fiscal fields.

Technical Highlights
- Precision: Used decimal(12,2) for all monetary amounts to prevent rounding errors.
- Security: Enforced a unique constraint on the UUID to prevent duplicate invoice uploads.
- Compatibility: Fields are set as nullable to maintain support for existing development seeds.