### PR TITLE
feat(backend): Added Iata codes (#130)

### DIFF
--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -110,7 +110,10 @@ In another terminal:
 ```powershell
 cd D:\Escritorio\TEC\Ditta\Monarca_Backend_clone\monarca
 npm run db:seed
+npm run db:import
 ```
+
+Use `npm run db:import` to sync destinations from `data/ourairports/airports_clean.csv`.
 
 ### F) Start frontend
 
@@ -207,6 +210,7 @@ From `Monarca_Backend_clone\monarca`:
 
 ```powershell
 npm run db:seed
+npm run db:import
 ```
 
 ---
@@ -555,6 +559,7 @@ npm run start:dev
 ```bash
 cd ~/Monarca/Monarca_Backend/monarca
 npm run db:seed
+npm run db:import
 ```
 
 > ⏱️ Wait in between 10 to 15 seconds after starting up the backend before running the seed command.
@@ -636,6 +641,7 @@ npm run db:truncate
 
 # To populate again
 npm run db:seed
+npm run db:import
 ```
 
 ---
@@ -662,6 +668,7 @@ npm install
 2. Restart the backend (`CTRL + C` and `npm run start:dev`)
 3. Wait for a full start
 4. Execute `npm run db:seed`
+5. Execute `npm run db:import`
 
 ### Error: "Unable to connect to the database"
 **Cause**: Docker is not running or not accessible by WSL.

--- a/monarca/migrations/1777066800000-AddProviderSupportStatusToRequestsDestinations.ts
+++ b/monarca/migrations/1777066800000-AddProviderSupportStatusToRequestsDestinations.ts
@@ -1,0 +1,47 @@
+/**
+ * FileName: 1777066800000-AddProviderSupportStatusToRequestsDestinations.ts
+ * Description: Adds provider support tracking columns to requests_destinations
+ *              to represent pending/supported/unsupported compatibility state.
+ * Authors: Diego de la Vega
+ * Last Modification made:
+ * 20/04/2026 [Diego de la Vega] Created migration to add provider support status,
+ *                             reason, and checked timestamp columns.
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProviderSupportStatusToRequestsDestinations1777066800000
+  implements MigrationInterface
+{
+  name = 'AddProviderSupportStatusToRequestsDestinations1777066800000';
+
+  /**
+   * up - Adds provider support metadata columns to requests_destinations.
+   */
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "requests_destinations" ADD "provider_support_status" character varying(40) NOT NULL DEFAULT 'pending_provider'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "requests_destinations" ADD "provider_support_reason" text`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "requests_destinations" ADD "provider_support_checked_at" TIMESTAMP`,
+    );
+  }
+
+  /**
+   * down - Reverts provider support metadata columns from requests_destinations.
+   */
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "requests_destinations" DROP COLUMN "provider_support_checked_at"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "requests_destinations" DROP COLUMN "provider_support_reason"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "requests_destinations" DROP COLUMN "provider_support_status"`,
+    );
+  }
+}

--- a/monarca/package.json
+++ b/monarca/package.json
@@ -18,6 +18,7 @@
     "setup:env": "node scripts/setup-env.cjs",
     "check:env": "node scripts/setup-env.cjs --check",
     "db:seed": "ts-node -r tsconfig-paths/register -r source-map-support/register -r dotenv/config ./seed.ts --seed",
+    "db:import": "ts-node -r tsconfig-paths/register -r source-map-support/register -r dotenv/config ./src/scripts/import-destinations.ts",
     "db:truncate": "ts-node -r tsconfig-paths/register -r source-map-support/register -r dotenv/config ./seed.ts --truncate",
     "db:drop": "ts-node -r tsconfig-paths/register -r source-map-support/register -r dotenv/config ./seed.ts --drop",
     "migration:generate": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js -d src/data-source.ts migration:generate ./migrations/%npm_config_name%",

--- a/monarca/seeds dev/destinations.json
+++ b/monarca/seeds dev/destinations.json
@@ -1,16 +1,22 @@
 [
     {
       "id": "d7ee631a-c1b8-42f0-8ae6-cd4d6b23470f",
+      "iata_code": "MEX",
+      "airport_name": "Aeropuerto Internacional Benito Juarez",
       "country": "Mexico",
       "city": "Mexico City"
     },
     {
       "id": "04963809-842e-457a-97aa-ac885bd6e1bf",
+      "iata_code": "JFK",
+      "airport_name": "John F. Kennedy International Airport",
       "country": "USA",
       "city": "New York"
     },
     {
       "id": "19283055-1ce3-48ea-a05a-04ae53978dfe",
+      "iata_code": "CDG",
+      "airport_name": "Charles de Gaulle Airport",
       "country": "France",
       "city": "Paris"
     }

--- a/monarca/seeds/destinations.json
+++ b/monarca/seeds/destinations.json
@@ -1,16 +1,22 @@
 [
     {
       "id": "d7ee631a-c1b8-42f0-8ae6-cd4d6b23470f",
+      "iata_code": "MEX",
+      "airport_name": "Aeropuerto Internacional Benito Juarez",
       "country": "Mexico",
       "city": "Mexico City"
     },
     {
       "id": "04963809-842e-457a-97aa-ac885bd6e1bf",
+      "iata_code": "JFK",
+      "airport_name": "John F. Kennedy International Airport",
       "country": "USA",
       "city": "New York"
     },
     {
       "id": "19283055-1ce3-48ea-a05a-04ae53978dfe",
+      "iata_code": "CDG",
+      "airport_name": "Charles de Gaulle Airport",
       "country": "France",
       "city": "Paris"
     }

--- a/monarca/src/destinations/destinations.service.ts
+++ b/monarca/src/destinations/destinations.service.ts
@@ -7,6 +7,8 @@
  * Last Modification made:
  * 11/04/2026 [Julio Rodriguez] Standardized client error handling to
  *                              BadRequestException for HTTP 400 policy.
+ * 20/04/2026 [Diego de la Vega] Ensured create/update operations persist
+ *                             iata_code and airport_name fields.
  */
 
 import { BadRequestException, Injectable } from '@nestjs/common';
@@ -25,6 +27,8 @@ export class DestinationsService {
 
   async create(data: CreateDestinationDto): Promise<Destination> {
     const dest = this.destRepo.create({
+      iata_code: data.iata_code,
+      airport_name: data.airport_name,
       country: data.country,
       city: data.city,
     });
@@ -45,6 +49,10 @@ export class DestinationsService {
 
   async update(id: string, data: UpdateDestinationDto): Promise<Destination> {
     await this.destRepo.update(id, {
+      ...(data.iata_code !== undefined && { iata_code: data.iata_code }),
+      ...(data.airport_name !== undefined && {
+        airport_name: data.airport_name,
+      }),
       ...(data.country !== undefined && { country: data.country }),
       ...(data.city !== undefined && { city: data.city }),
     });

--- a/monarca/src/requests/entities/requests-destination.entity.ts
+++ b/monarca/src/requests/entities/requests-destination.entity.ts
@@ -1,3 +1,14 @@
+/**
+ * FileName: requests-destination.entity.ts
+ * Description: Request destination entity. Stores each destination leg associated
+ *              with a travel request, including reservation requirements and
+ *              provider support metadata for compatibility checks.
+ * Authors: Original Monarca team
+ * Last Modification made:
+ * 20/04/2026 [Diego de la Vega] Added provider support status fields to track
+ *                             pending/supported/unsupported destination legs.
+ */
+
 import {
   Entity,
   PrimaryGeneratedColumn,
@@ -45,6 +56,20 @@ export class RequestsDestination {
 
   @Column({ name: 'details', nullable: true })
   details: string;
+
+  @Column({
+    name: 'provider_support_status',
+    type: 'varchar',
+    length: 40,
+    default: 'pending_provider',
+  })
+  provider_support_status: string;
+
+  @Column({ name: 'provider_support_reason', type: 'text', nullable: true })
+  provider_support_reason: string | null;
+
+  @Column({ name: 'provider_support_checked_at', type: 'timestamp', nullable: true })
+  provider_support_checked_at: Date | null;
 
   // Relationships
 

--- a/monarca/src/requests/requests.service.ts
+++ b/monarca/src/requests/requests.service.ts
@@ -6,6 +6,8 @@
  * Last Modification made:
  * 11/04/2026 [Julio Rodriguez] Standardized request errors to 400/500 policy
  *                              and aligned service header documentation.
+ * 20/04/2026 [Diego de la Vega] Added default provider support metadata for
+ *                             requests_destinations on create and update.
  */
 
 import {
@@ -244,6 +246,9 @@ export class RequestsService {
       exchange_rate: finalExchangeRate,
       requests_destinations: data.requests_destinations.map((destDto) => ({
         ...destDto,
+        provider_support_status: 'pending_provider',
+        provider_support_reason: null,
+        provider_support_checked_at: null,
       })),
     });
 
@@ -544,7 +549,12 @@ export class RequestsService {
       //Overhaul de requests_destinations
       const destRepo = manager.getRepository(RequestsDestination);
       entity.requests_destinations = data.requests_destinations.map((d) =>
-        destRepo.create({ ...d }),
+        destRepo.create({
+          ...d,
+          provider_support_status: 'pending_provider',
+          provider_support_reason: null,
+          provider_support_checked_at: null,
+        }),
       );
 
       //Update status


### PR DESCRIPTION
This pull request introduces support for tracking provider compatibility status for each destination leg in travel requests, improves the handling of airport metadata, and updates documentation and seed data to reflect these changes.
Closes #130 