### PR TITLE
bugfix(migrations): DB migrations fixes

### DIFF
--- a/monarca/migrations/1776988508043-Database_v2.ts
+++ b/monarca/migrations/1776988508043-Database_v2.ts
@@ -7,12 +7,12 @@
  *              - Replaces deprecated tax_amount/retention_amount with CFDI fiscal
  *                fields on vouchers (receiver_name, exchange_rate, discount,
  *                iva_trasladado, ieps_trasladado, isr_retenido, iva_retenido,
- *                payment_form, payment_method)
+ *                payment_form, payment_method, unconverted_amount)
  *              - Consolidates FK onDelete rules for users and cost_centers
  *              - Adds current_approval_level_id nullable FK to requests
  * Authors: DebugStudio Team
  * Last Modification made:
- * 23/04/2026 [Julio Rodríguez] Consolidated from 5 individual migrations into Database_v2.
+ * 27/04/2026 [Julio Rodríguez] Added unconverted_amount to vouchers.
  */
 
 import { MigrationInterface, QueryRunner } from 'typeorm';
@@ -55,6 +55,7 @@ export class DatabaseV21776988508043 implements MigrationInterface {
         await queryRunner.query(`ALTER TABLE "vouchers" ADD "iva_retenido" numeric(12,2)`);
         await queryRunner.query(`ALTER TABLE "vouchers" ADD "payment_form" character varying`);
         await queryRunner.query(`ALTER TABLE "vouchers" ADD "payment_method" character varying`);
+        await queryRunner.query(`ALTER TABLE "vouchers" ADD "unconverted_amount" numeric(12,2)`);
         await queryRunner.query(`ALTER TABLE "request_approvals" ALTER COLUMN "amount_snapshot" TYPE numeric`);
         await queryRunner.query(`ALTER TABLE "approval_levels" ALTER COLUMN "min_amount_mon" TYPE numeric`);
         await queryRunner.query(`ALTER TABLE "approval_levels" ALTER COLUMN "max_amount_mon" TYPE numeric`);
@@ -97,6 +98,7 @@ export class DatabaseV21776988508043 implements MigrationInterface {
         await queryRunner.query(`ALTER TABLE "approval_levels" ALTER COLUMN "max_amount_mon" TYPE numeric`);
         await queryRunner.query(`ALTER TABLE "approval_levels" ALTER COLUMN "min_amount_mon" TYPE numeric`);
         await queryRunner.query(`ALTER TABLE "request_approvals" ALTER COLUMN "amount_snapshot" TYPE numeric`);
+        await queryRunner.query(`ALTER TABLE "vouchers" DROP COLUMN "unconverted_amount"`);
         await queryRunner.query(`ALTER TABLE "vouchers" DROP COLUMN "payment_method"`);
         await queryRunner.query(`ALTER TABLE "vouchers" DROP COLUMN "payment_form"`);
         await queryRunner.query(`ALTER TABLE "vouchers" DROP COLUMN "iva_retenido"`);

--- a/monarca/src/vouchers/entities/vouchers.entity.ts
+++ b/monarca/src/vouchers/entities/vouchers.entity.ts
@@ -6,6 +6,7 @@
  * Authors: Original Monarca team
  * Last Modification made:
  * 20/04/2026 [fest] Added receiver_name and exchange_rate fiscal fields for CFDI integration.
+ * 22/04/2026 [Sebastián Borjas] Added unconverted_amount column to store original foreign-currency amount.
  */
 
 import {
@@ -31,6 +32,9 @@ export class Voucher {
 
   @Column({ name: 'amount', type: 'decimal', precision: 12, scale: 2 })
   amount: number;
+
+  @Column({ name: 'unconverted_amount', type: 'decimal', precision: 12, scale: 2, nullable: true })
+  unconverted_amount: number | null;
 
   @Column({ name: 'tax_type', type: 'varchar' })
   tax_type: string;

--- a/monarca/src/vouchers/vouchers.service.ts
+++ b/monarca/src/vouchers/vouchers.service.ts
@@ -2,21 +2,38 @@
  * FileName: vouchers.service
  * Description: Business logic layer for Voucher operations. Handles creation,
  *              retrieval, update, deletion, approval, and denial of vouchers.
- *              Enforces ownership rules and validates referenced request existence.
+ *              Enforces ownership rules, validates referenced request existence,
+ *              and performs currency conversion via DB cache or Banxico API.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 11/04/2026 [Julio Rodriguez] Standardized client error handling to
- *                              BadRequestException for HTTP 400 policy and
- *                              aligned header documentation.
+ * 22/04/2026 [Sebastián Borjas] Added multi-currency support: DB-cached exchange
+ *                               rates with Banxico API fallback, unconverted_amount
+ *                               stored alongside MXN-converted amount.
  */
 
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, UpdateResult } from 'typeorm';
+import { DataSource, Repository, UpdateResult } from 'typeorm';
 import { CreateVoucherDto } from './dto/create-voucher-dto';
 import { UpdateVoucherDto } from './dto/update-voucher-dto';
 import { Voucher } from './entities/vouchers.entity';
 import { Request } from 'src/requests/entities/request.entity';
+
+const BANXICO_CURRENCY_MAPPING: Record<string, string> = {
+  USD: 'SF43718',
+  EUR: 'SF46410',
+  JPY: 'SF46406',
+  GBP: 'SF46407',
+  CAD: 'SF60632',
+  CHF: 'SF46405',
+  CNY: 'SF290383',
+  BRL: 'SF290312',
+  ARS: 'SF290311',
+  CLP: 'SF290351',
+  COP: 'SF290382',
+  SDR: 'SF46411',
+};
+
 @Injectable()
 export class VouchersService {
   constructor(
@@ -24,19 +41,99 @@ export class VouchersService {
     private readonly voucherRepo: Repository<Voucher>,
     @InjectRepository(Request)
     private readonly rRepo: Repository<Request>,
+    private readonly dataSource: DataSource,
   ) {}
+
+  /**
+   * fetchBanxicoRate - Fetches the latest exchange rate for a given currency from the Banxico API.
+   * Input: currency (string) - ISO 4217 currency code.
+   * Output: Promise<number | null> - exchange rate in MXN, or null if unavailable.
+   */
+  private async fetchBanxicoRate(currency: string): Promise<number | null> {
+    const banxicoId = BANXICO_CURRENCY_MAPPING[currency];
+    if (!banxicoId) return null;
+
+    const bmxToken = process.env['BMX-TOKEN'];
+    if (!bmxToken) {
+      console.warn('BMX-TOKEN is not set in environment.');
+      return null;
+    }
+
+    try {
+      const url = `https://www.banxico.org.mx/SieAPIRest/service/v1/series/${banxicoId}/datos/oportuno`;
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          'Bmx-Token': bmxToken,
+          'Accept': 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        console.error(`Banxico API error: ${response.statusText}`);
+        return null;
+      }
+
+      const rawData = await response.json();
+      const series = rawData?.bmx?.series?.[0];
+      const data = series?.datos?.[0];
+
+      if (data && data.dato) {
+        const rate = parseFloat(data.dato);
+        return isNaN(rate) ? null : rate;
+      }
+      return null;
+    } catch (error) {
+      console.error('Failed to fetch from Banxico API:', error);
+      return null;
+    }
+  }
+
+  /**
+   * resolveExchangeRate - Returns today's exchange rate for a currency, using the DB
+   *                       cache first and falling back to the Banxico API.
+   *                       Persists newly fetched rates to the DB for future requests.
+   * Input: currency (string) - ISO 4217 currency code.
+   * Output: Promise<number | null> - exchange rate in MXN, or null if unavailable.
+   */
+  private async resolveExchangeRate(currency: string): Promise<number | null> {
+    const now = new Date();
+    const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+
+    const rows = await this.dataSource.query(
+      `SELECT exchange_rate FROM exchange_rates WHERE currency = $1 AND update_date = $2`,
+      [currency, todayStr],
+    );
+
+    if (rows && rows.length > 0) {
+      return Number(rows[0].exchange_rate);
+    }
+
+    console.log(`No exchange rate in DB for ${currency} on ${todayStr}. Fetching from Banxico...`);
+    const fetchedRate = await this.fetchBanxicoRate(currency);
+
+    if (fetchedRate !== null) {
+      await this.dataSource.query(
+        `INSERT INTO exchange_rates (currency, exchange_rate, update_date) VALUES ($1, $2, $3)`,
+        [currency, fetchedRate, todayStr],
+      );
+    }
+
+    return fetchedRate;
+  }
 
   /**
    * create - Creates and persists a new voucher. Validates that the referenced
    *          request exists and that the caller is the owner of that request.
+   *          For non-MXN currencies, resolves the exchange rate and converts the
+   *          amount to MXN, storing the original amount in unconverted_amount.
    * Input: id_user (string) - UUID of the authenticated user creating the voucher;
-   *        data (CreateVoucherDto) - voucher fields: id_request, class, amount,
-   *        currency, tax_type, date, file_url_pdf, file_url_xml, status.
+   *        data (CreateVoucherDto) - voucher fields.
    * Output: Promise<Voucher> - the newly saved voucher entity.
-  * Throws BadRequestException if the referenced request does not exist.
-  * Throws BadRequestException if the caller is not the request owner.
+   * Throws BadRequestException if the referenced request does not exist.
+   * Throws BadRequestException if the caller is not the request owner.
    */
-  async create(id_user:string, data: CreateVoucherDto): Promise<Voucher> {
+  async create(id_user: string, data: CreateVoucherDto): Promise<Voucher> {
     const request = await this.rRepo.findOne({
       where: { id: data.id_request },
     });
@@ -46,23 +143,39 @@ export class VouchersService {
       );
     }
     const approverId = request.id_admin;
-    const id_creator= request.id_user;
+    const id_creator = request.id_user;
     if (id_user !== id_creator) {
       throw new BadRequestException(
         `User ${id_user} is not authorized to create a voucher for this request`,
       );
     }
+
+    let finalAmount: number = data.amount;
+    let unconvertedAmount: number | null = null;
+    let exchangeRate: number | null = null;
+
+    if (data.currency && data.currency !== 'MXN') {
+      const rate = await this.resolveExchangeRate(data.currency);
+      if (rate !== null) {
+        exchangeRate = rate;
+        unconvertedAmount = data.amount;
+        finalAmount = Math.round(data.amount * rate * 100) / 100;
+      }
+    }
+
     const voucher = this.voucherRepo.create({
-      id_request: data.id_request, // Using the correct DTO property
+      id_request: data.id_request,
       class: data.class,
-      amount: data.amount,
+      amount: finalAmount,
+      unconverted_amount: unconvertedAmount,
       currency: data.currency,
       tax_type: data.tax_type,
-      date: new Date(data.date), // Ensuring that the date is correctly parsed
+      date: new Date(data.date),
       file_url_pdf: data.file_url_pdf,
       file_url_xml: data.file_url_xml,
       status: data.status,
-      id_approver: approverId, // Mapping the correct file URL
+      id_approver: approverId,
+      exchange_rate: exchangeRate,
     });
     return await this.voucherRepo.save(voucher);
   }
@@ -94,29 +207,26 @@ export class VouchersService {
    * update - Partially updates a voucher's fields. Only fields present in the
    *          DTO overwrite existing values; omitted fields keep their current values.
    * Input: id (string) - UUID of the voucher to update;
-   *        data (UpdateVoucherDto) - optional fields to apply (class, amount, currency,
-   *        tax_type, date, file_url_pdf, file_url_xml, status, id_request).
+   *        data (UpdateVoucherDto) - optional fields to apply.
    * Output: Promise<Voucher> - the voucher entity after applying the updates.
    */
   async update(id: string, data: UpdateVoucherDto): Promise<Voucher> {
-    const existingVoucher = await this.findOne(id); // Ensure we find the voucher first
+    const existingVoucher = await this.findOne(id);
 
     const updatedVoucherData = {
-      // Update only provided fields
-      id_request:data.id_request ?? existingVoucher.id_request, // Use existing if not provided
-      class: data.class ?? existingVoucher.class, // Use existing if not provided
-      amount: data.amount ?? existingVoucher.amount, // Use existing if not provided
-      tax_type: data.tax_type ?? existingVoucher.tax_type, // Use existing if not provided
-      currency: data.currency ?? existingVoucher.currency, // Use existing if not provided
-      date: data.date ? new Date(data.date) : existingVoucher.date, // Update only if new date is provided
-      file_url_pdf: data.file_url_pdf ?? existingVoucher.file_url_pdf, // Use existing if not provided
-      file_url_xml: data.file_url_xml ?? existingVoucher.file_url_xml, // Use existing if not provided
+      id_request: data.id_request ?? existingVoucher.id_request,
+      class: data.class ?? existingVoucher.class,
+      amount: data.amount ?? existingVoucher.amount,
+      tax_type: data.tax_type ?? existingVoucher.tax_type,
+      currency: data.currency ?? existingVoucher.currency,
+      date: data.date ? new Date(data.date) : existingVoucher.date,
+      file_url_pdf: data.file_url_pdf ?? existingVoucher.file_url_pdf,
+      file_url_xml: data.file_url_xml ?? existingVoucher.file_url_xml,
       status: data.status ?? existingVoucher.status,
     };
 
-    // Now update and return the updated entity
     await this.voucherRepo.update(id, updatedVoucherData);
-    return this.findOne(id); // Return the updated entity
+    return this.findOne(id);
   }
 
   /**
@@ -132,66 +242,56 @@ export class VouchersService {
     }
     return { status: true, message: `Voucher with ID ${id} removed` };
   }
+
   /**
    * approve - Sets a voucher's status to 'Voucher Approved'.
    * Input: id (string) - UUID of the voucher to approve.
    * Output: Promise<{ status: boolean; message: string }> - success flag and confirmation message.
-  * Throws BadRequestException if no voucher with the given ID exists.
-   */  
+   * Throws BadRequestException if no voucher with the given ID exists.
+   */
   async approve(id: string): Promise<{ status: boolean; message: string }> {
-    // 1) run the update
     const result: UpdateResult = await this.voucherRepo.update(id, {
-      status: 'Voucher Approved',         // ← your “determined value” here
+      status: 'Voucher Approved',
     });
 
-    // 2) if nothing was affected, the id didn’t exist
     if (result.affected === 0) {
       throw new BadRequestException(`Voucher with ID ${id} not found`);
     }
 
-    // 3) return a success payload
-    return {
-      status: true,
-      message: `Voucher ${id} approved`,
-    };
+    return { status: true, message: `Voucher ${id} approved` };
   }
+
   /**
    * deny - Sets a voucher's status to 'Voucher Denied'.
    * Input: id (string) - UUID of the voucher to deny.
    * Output: Promise<{ status: boolean; message: string }> - success flag and confirmation message.
-  * Throws BadRequestException if no voucher with the given ID exists.
-   */  
+   * Throws BadRequestException if no voucher with the given ID exists.
+   */
   async deny(id: string): Promise<{ status: boolean; message: string }> {
-    // 1) run the update
     const result: UpdateResult = await this.voucherRepo.update(id, {
-      status: 'Voucher Denied',         // ← your “determined value” here
+      status: 'Voucher Denied',
     });
 
-    // 2) if nothing was affected, the id didn’t exist
     if (result.affected === 0) {
       throw new BadRequestException(`Voucher with ID ${id} not found`);
     }
 
-    // 3) return a success payload
-    return {
-      status: true,
-      message: `Voucher ${id} denied`,
-    };
+    return { status: true, message: `Voucher ${id} denied` };
   }
 
   /**
    * findByRequest - Retrieves all vouchers linked to a specific travel request.
    * Input: requestId (string) - UUID of the travel request to filter vouchers by.
    * Output: Promise<Voucher[]> - array of vouchers associated with the given request.
-  * Throws BadRequestException if no vouchers exist for the given request ID.
+   * Throws BadRequestException if no vouchers exist for the given request ID.
    */
   async findByRequest(requestId: string): Promise<Voucher[]> {
     const vouchers = await this.voucherRepo.find({
-      where: { id_request: requestId},
+      where: { id_request: requestId },
     });
     if (vouchers.length === 0) {
       throw new BadRequestException(
-        `No vouchers found for Request ID ${requestId}`
+        `No vouchers found for Request ID ${requestId}`,
       );
     }
     return vouchers;


### PR DESCRIPTION
### Database & Seeds
- `Database_v2` migration: consolidates 5 previous individual migrations into a single file + `unconverted_amount` column on `vouchers` (missing from PR #170)
- `seeds/users.json`: added admin seed users (`admin@ditta.com`, `admin@monarcamx.com`, `admin@monarcaus.com`) and full role coverage per company
- `seeds/permissions.json`: added `view_approved_request_history` permission
- `seeds/roles-permissions.json`: corrected permission assignments per architecture (removed `approve_vouchers`, `deny_vouchers`, `assign_request_to_travel_agency` from Approver; added to SOI)
- `seed.service.ts`: fixed truncation order to include `approval_levels` and `approval_levels_actors`

### Bugfixes
- `GET /requests/to-approve` — corrected permission from `view_assigned_requests_readonly` to `approve_request`
- `GET /requests/approved-history` — new endpoint with `view_approved_request_history` permission (infrastructure for upcoming permissions refactor)

## PR Targeting Checklist

- [x] This PR targets the `develop` branch (for most changes)
- [ ] This PR targets the `main` branch (ONLY for release branches or hotfixes)

> ⚠️ IMPORTANT: PRs to `main` should only come from `develop` or release branches.
> If this is a feature or bugfix PR, please retarget to `develop`.