### PR TITLE
fix(seeds): remove request_history permission from Solicitante role

### DIFF
--- a/monarca/seeds/roles-permissions.json
+++ b/monarca/seeds/roles-permissions.json
@@ -3,7 +3,6 @@
   { "id_role": "b0d4211d-457e-4d84-b8a4-320af380683f", "id_permission": "144d80a2-24b9-4826-a9bd-28d61d52c432" },
   { "id_role": "b0d4211d-457e-4d84-b8a4-320af380683f", "id_permission": "5d110d2b-8df6-413e-9255-9886faa598a5" },
   { "id_role": "b0d4211d-457e-4d84-b8a4-320af380683f", "id_permission": "b4904143-de77-4557-aa04-2d9c7141666f" },
-  { "id_role": "b0d4211d-457e-4d84-b8a4-320af380683f", "id_permission": "3e9ad5bb-563b-493f-8b67-808371e34e28" },
   { "id_role": "b0d4211d-457e-4d84-b8a4-320af380683f", "id_permission": "07aac50a-e679-4a7e-b6d8-6eaec6270846" },
 
   { "id_role": "8f28d424-2d93-483a-9018-f568cf6bc13a", "id_permission": "6ccf23e4-3ed3-40aa-8eac-6473704acf0c" },


### PR DESCRIPTION
## Summary

- Removed the `request_history` permission from the Solicitante (requester) role in the seed data, preventing requesters from accessing the trip registration view they should not see.

## Test plan
- [x] Run `npm run db:drop`, `npm run migration:run`, `npm run db:seed`, `npm run db:import`
- [x] Log in as `requester1@monarca.com`
- [x] Verify the "viajes por registrar" view is no longer visible