### PR TITLE
fix(backend): added necessary permission to requester

### DIFF
--- a/monarca/src/guards/permissions.guard.ts
+++ b/monarca/src/guards/permissions.guard.ts
@@ -23,7 +23,7 @@ import { RequestInterface } from './interfaces/request.interface';
 
 // Map of user boolean flags to their corresponding permissions. Used to derive a user's permissions based on their flags without needing a DB join to roles_permissions.
 export const FLAG_PERMISSIONS: Record<string, string[]> = {
-  is_requester: ['create_request', 'edit_request', 'delete_request', 'upload_vouchers', 'request_history'],
+  is_requester: ['create_request', 'edit_request', 'delete_request', 'upload_vouchers', 'request_history', 'view_assigned_requests_readonly'],
   is_approver: ['approve_request', 'deny_request', 'request_changes', 'view_approved_request_history'],
   is_soi: ['check_budgets', 'approve_budget', 'deny_budget', 'assign_request_to_travel_agency', 'approve_vouchers', 'deny_vouchers', 'view_assigned_requests_readonly'],
   is_travelAgent: ['view_assigned_requests_readonly', 'submit_reservations', 'send_reservation_receipts'],


### PR DESCRIPTION
This pull request makes a small update to the `FLAG_PERMISSIONS` mapping in `permissions.guard.ts` to expand the permissions granted to users with the `is_requester` flag.

- Added the `view_assigned_requests_readonly` permission to the list of permissions for users with the `is_requester` flag in the `FLAG_PERMISSIONS` mapping (`permissions.guard.ts`).