### PR TITLE
fix(guard): replace request_history with view_own_requests for requester

### DIFF
--- a/monarca/seeds dev/permissions.json
+++ b/monarca/seeds dev/permissions.json
@@ -55,11 +55,7 @@
     "id": "07aac50a-e679-4a7e-b6d8-6eaec6270846",
     "name": "view_assigned_requests_readonly"
   },
-  {
-    "id": "3e9ad5bb-563b-493f-8b67-808371e34e28",
-    "name": "request_history"
-  },
-  {
+{
     "id": "7fedb986-8761-4ffd-aa85-71e73a41f85d",
     "name": "submit_reservations"
   },

--- a/monarca/seeds/permissions.json
+++ b/monarca/seeds/permissions.json
@@ -55,11 +55,7 @@
     "id": "07aac50a-e679-4a7e-b6d8-6eaec6270846",
     "name": "view_assigned_requests_readonly"
   },
-  {
-    "id": "3e9ad5bb-563b-493f-8b67-808371e34e28",
-    "name": "request_history"
-  },
-  {
+{
     "id": "7fedb986-8761-4ffd-aa85-71e73a41f85d",
     "name": "submit_reservations"
   },

--- a/monarca/src/guards/permissions.guard.ts
+++ b/monarca/src/guards/permissions.guard.ts
@@ -23,7 +23,7 @@ import { RequestInterface } from './interfaces/request.interface';
 
 // Map of user boolean flags to their corresponding permissions. Used to derive a user's permissions based on their flags without needing a DB join to roles_permissions.
 export const FLAG_PERMISSIONS: Record<string, string[]> = {
-  is_requester: ['create_request', 'edit_request', 'delete_request', 'upload_vouchers', 'request_history', 'view_assigned_requests_readonly'],
+  is_requester: ['create_request', 'edit_request', 'delete_request', 'upload_vouchers', 'view_own_requests', 'view_assigned_requests_readonly'],
   is_approver: ['approve_request', 'deny_request', 'request_changes', 'view_approved_request_history'],
   is_soi: ['check_budgets', 'approve_budget', 'deny_budget', 'assign_request_to_travel_agency', 'approve_vouchers', 'deny_vouchers', 'view_assigned_requests_readonly'],
   is_travelAgent: ['view_assigned_requests_readonly', 'submit_reservations', 'send_reservation_receipts'],


### PR DESCRIPTION
## Summary
- \`request_history\` was incorrectly assigned to the requester in \`FLAG_PERMISSIONS\` — it is an orphaned permission not used by any endpoint or UI component
- Replaced with \`view_own_requests\`, the permission created specifically for the requester to view their own request history (introduced in PR #185)
- Removed \`request_history\` from both seed files (\`seeds/\` and \`seeds dev/\`) since it is no longer assigned to any role

## ⚠️ To test this fix both repos must be on this branch
Frontend companion PR: Equipo2-TC3004B-102/Monarca_Frontend#90

```bash
# Backend
git checkout bugfix/requester-view-own-requests-guard
npm run db:drop && npm run migration:run && npm run db:seed && npm run db:import

# Frontend
git checkout bugfix/requester-view-own-requests-guard
npm run dev
```

## Test plan
- [ ] Login as Solicitante and verify "Historial de viajes" appears in sidebar and dashboard
- [ ] Verify the history loads correctly (GET /requests/user returns 200)