### PR TITLE
feat(admin): add company info endpoint; fix reservation price coercion

### DIFF
--- a/monarca/seed.service.ts
+++ b/monarca/seed.service.ts
@@ -5,7 +5,7 @@
  *              backwards-compatible field normalization (id_ceco, user_name).
  * Authors: Original Monarca team
  * Last Modification made:
- * 23/04/2026 [Julio Rodríguez] Fixed header; added approval_levels tables to truncate list.
+ * 13/05/2026 [Julio Rodriguez] Added request_approvals to truncate list — missing FK reference caused truncate to fail when request approvals existed.
  */
 
 import { Injectable, Logger } from '@nestjs/common';
@@ -170,6 +170,7 @@ export class SeedService {
                 'request_logs',
                 'reservations',
                 'requests_destinations',
+                'request_approvals',
                 'requests',
                 'user_logs',
                 'users',

--- a/monarca/src/approval-engine/admin.controller.ts
+++ b/monarca/src/approval-engine/admin.controller.ts
@@ -8,6 +8,7 @@
  *              to system admins exclusively.
  * Authors: DebugStudio Team
  * Last Modification:
+ * 13/05/2026 [Julio Rodriguez] Added GET /admin/companies/:companyId/cost-centers endpoint.
  * 03/05/2026 [Julio Rodriguez] GET /admin/users now accessible to both admins; results scoped by service.
  * 29/04/2026 [Julio Rodriguez] Added POST /admin/companies/setup endpoint.
  * 28/04/2026 [Julio Rodríguez] Created AdminController with company CRUD and user management.
@@ -116,6 +117,20 @@ export class AdminController {
   }
 
   // Company-scoped user management (company admin and system admin)
+
+  /**
+   * getCostCentersByCompany — Returns all cost centers belonging to a company.
+   * Company admins can only access their own company. System admins access any.
+   * Input: companyId path param (uuid).
+   * Output: CostCenter array.
+   */
+  @Get('companies/:companyId/cost-centers')
+  async getCostCentersByCompany(
+    @Param('companyId', new ParseUUIDPipe()) companyId: string,
+    @Req() req: RequestInterface,
+  ) {
+    return this.adminService.getCostCentersByCompany(companyId, req.userInfo);
+  }
 
   /**
    * findUsersByCompany — Returns users belonging to a company with optional filters.

--- a/monarca/src/approval-engine/admin.controller.ts
+++ b/monarca/src/approval-engine/admin.controller.ts
@@ -9,9 +9,7 @@
  * Authors: DebugStudio Team
  * Last Modification:
  * 13/05/2026 [Julio Rodriguez] Added GET /admin/companies/:companyId/cost-centers endpoint.
- * 03/05/2026 [Julio Rodriguez] GET /admin/users now accessible to both admins; results scoped by service.
- * 29/04/2026 [Julio Rodriguez] Added POST /admin/companies/setup endpoint.
- * 28/04/2026 [Julio Rodríguez] Created AdminController with company CRUD and user management.
+ *                              Added GET /admin/companies/:companyId/info endpoint (company admin + system admin).
  */
 
 import {
@@ -117,6 +115,20 @@ export class AdminController {
   }
 
   // Company-scoped user management (company admin and system admin)
+
+  /**
+   * getCompanyInfo — Returns basic company info for the given company.
+   * Company admins can only access their own company. System admins access any.
+   * Input: companyId path param (uuid).
+   * Output: Company entity.
+   */
+  @Get('companies/:companyId/info')
+  async getCompanyInfo(
+    @Param('companyId', new ParseUUIDPipe()) companyId: string,
+    @Req() req: RequestInterface,
+  ) {
+    return this.adminService.getCompanyInfo(companyId, req.userInfo);
+  }
 
   /**
    * getCostCentersByCompany — Returns all cost centers belonging to a company.

--- a/monarca/src/approval-engine/admin.service.ts
+++ b/monarca/src/approval-engine/admin.service.ts
@@ -8,6 +8,7 @@
  * Authors: DebugStudio Team
  * Last Modification made:
  * 13/05/2026 [Julio Rodriguez] Added getCostCentersByCompany for CECO selector in AdminRules.
+ *                              Added getCompanyInfo for company name display in AdminRules (accessible to company admins).
  */
 
 import {
@@ -318,6 +319,22 @@ export class AdminService {
     const { password, ...adminWithoutPassword } = savedAdmin;
 
     return { company, admin: adminWithoutPassword };
+  }
+
+  /**
+   * getCompanyInfo — Returns basic company info (id, name, local_currency) for the given company.
+   * Company admins can only access their own company. System admins access any.
+   * Input: company id, caller userInfo.
+   * Output: Company entity.
+   */
+  async getCompanyInfo(companyId: string, caller: UserInfoInterface): Promise<Company> {
+    if (!caller.is_system_admin && caller.id_company !== companyId) {
+      throw this.clientError(
+        'Access restricted to your own company',
+        'ADMIN_FORBIDDEN_COMPANY',
+      );
+    }
+    return this.findOneCompany(companyId);
   }
 
   /**

--- a/monarca/src/approval-engine/admin.service.ts
+++ b/monarca/src/approval-engine/admin.service.ts
@@ -7,7 +7,7 @@
  *              Passwords are always hashed with bcrypt before being persisted.
  * Authors: DebugStudio Team
  * Last Modification made:
- * 03/05/2026 [Julio Rodriguez] findAllUsers now scopes results to caller's company when caller is not system admin.
+ * 13/05/2026 [Julio Rodriguez] Added getCostCentersByCompany for CECO selector in AdminRules.
  */
 
 import {
@@ -19,6 +19,7 @@ import { ILike, Repository } from 'typeorm';
 import * as bcrypt from 'bcrypt';
 import { Company } from 'src/companies/entity/company.entity';
 import { User } from 'src/users/entities/user.entity';
+import { CostCenter } from 'src/cost-centers/entity/cost-centers.entity';
 import { CreateCompanyDto, UpdateCompanyDto } from 'src/companies/dto/company.dtos';
 import { CreateUserDto, UpdateUserDto } from 'src/users/dto/user.dtos';
 import { CompanySetupDto, FindUsersQueryDto, SetCompanyAdminDto, SetUserFlagsDto } from './dto/admin.dto';
@@ -32,6 +33,9 @@ export class AdminService {
 
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
+
+    @InjectRepository(CostCenter)
+    private readonly costCenterRepository: Repository<CostCenter>,
   ) {}
 
   private clientError(message: string, code: string) {
@@ -314,5 +318,24 @@ export class AdminService {
     const { password, ...adminWithoutPassword } = savedAdmin;
 
     return { company, admin: adminWithoutPassword };
+  }
+
+  /**
+   * getCostCentersByCompany — Returns all cost centers belonging to a company.
+   * Company admins can only access their own company. System admins access any.
+   * Input: company id, caller userInfo.
+   * Output: CostCenter array.
+   */
+  async getCostCentersByCompany(
+    companyId: string,
+    caller: UserInfoInterface,
+  ): Promise<CostCenter[]> {
+    if (!caller.is_system_admin && caller.id_company !== companyId) {
+      throw this.clientError(
+        'Access restricted to your own company cost centers',
+        'ADMIN_FORBIDDEN_COMPANY',
+      );
+    }
+    return this.costCenterRepository.find({ where: { id_company: companyId } });
   }
 }

--- a/monarca/src/approval-engine/approval-engine.module.ts
+++ b/monarca/src/approval-engine/approval-engine.module.ts
@@ -5,7 +5,8 @@
  *              Also registers admin service and controller for company and user management.
  * Authors: DebugStudio Team
  * Last Modification made:
- * 06/05/2026 [Julio Rodriguez] Removed Roles entity from forFeature — RBAC tables dropped in Database_v4.
+ * 13/05/2026 [Julio Rodriguez] Added CostCenter to forFeature for CECO listing endpoint.
+ *                              Added Request entity to forFeature for request reassignment on level deletion.
  */
 
 import { Module } from '@nestjs/common';
@@ -20,6 +21,8 @@ import { AdminController } from './admin.controller';
 import { GuardsModule } from 'src/guards/guards.module';
 import { Company } from 'src/companies/entity/company.entity';
 import { User } from 'src/users/entities/user.entity';
+import { Request as RequestEntity } from 'src/requests/entities/request.entity';
+import { CostCenter } from 'src/cost-centers/entity/cost-centers.entity';
 
 @Module({
   imports: [
@@ -29,6 +32,8 @@ import { User } from 'src/users/entities/user.entity';
       RequestApproval,
       Company,
       User,
+      RequestEntity,
+      CostCenter,
     ]),
     GuardsModule,
   ],

--- a/monarca/src/approval-engine/approval-engine.service.ts
+++ b/monarca/src/approval-engine/approval-engine.service.ts
@@ -5,7 +5,6 @@
  *              to their own company; system admins can access all companies.
  * Authors: DebugStudio Team
  * Last Modification made:
- * 05/05/2026 [Julio Rodriguez] createApprovalLevel derives company_id from caller.id_company instead of DTO.
  * 13/05/2026 [Julio Rodriguez] removeApprovalLevel: reassign pending requests to substitute level before deleting; 400 if no substitute exists.
  */
 

--- a/monarca/src/approval-engine/approval-engine.service.ts
+++ b/monarca/src/approval-engine/approval-engine.service.ts
@@ -6,6 +6,7 @@
  * Authors: DebugStudio Team
  * Last Modification made:
  * 05/05/2026 [Julio Rodriguez] createApprovalLevel derives company_id from caller.id_company instead of DTO.
+ * 13/05/2026 [Julio Rodriguez] removeApprovalLevel: reassign pending requests to substitute level before deleting; 400 if no substitute exists.
  */
 
 import {
@@ -14,9 +15,11 @@ import {
   Injectable,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Not, Repository } from 'typeorm';
 import { ApprovalLevel } from './entities/approval-level.entity';
 import { ApprovalLevelActor } from './entities/approval-level-actor.entity';
+import { RequestApproval } from './entities/request-approval.entity';
+import { Request as RequestEntity } from 'src/requests/entities/request.entity';
 import { CreateApprovalLevelDto, UpdateApprovalLevelDto } from './dto/approval-level.dto';
 import { CreateApprovalLevelActorDto, UpdateApprovalLevelActorDto } from './dto/approval-level-actor.dto';
 import { UserInfoInterface } from 'src/guards/interfaces/userInfo.interface';
@@ -29,6 +32,12 @@ export class ApprovalEngineService {
 
     @InjectRepository(ApprovalLevelActor)
     private readonly approvalLevelActorRepository: Repository<ApprovalLevelActor>,
+
+    @InjectRepository(RequestEntity)
+    private readonly requestRepository: Repository<RequestEntity>,
+
+    @InjectRepository(RequestApproval)
+    private readonly requestApprovalRepository: Repository<RequestApproval>,
   ) {}
 
   private clientError(message: string, code: string) {
@@ -128,6 +137,9 @@ export class ApprovalEngineService {
 
   /**
    * removeApprovalLevel — Deletes an approval level by id.
+   * If pending requests exist at this level, finds a substitute at the same level_order
+   * within the same company and reassigns them atomically before deleting.
+   * Throws 400 APPROVAL_LEVEL_HAS_PENDING_REQUESTS when no substitute exists.
    * Input: level id, caller userInfo.
    * Output: deletion confirmation object.
    */
@@ -135,7 +147,41 @@ export class ApprovalEngineService {
     id: string,
     caller: UserInfoInterface,
   ): Promise<{ status: boolean; message: string }> {
-    await this.findOneApprovalLevel(id, caller);
+    const level = await this.findOneApprovalLevel(id, caller);
+
+    const pendingCount = await this.requestRepository.count({
+      where: { current_approval_level_id: id },
+    });
+
+    if (pendingCount > 0) {
+      const substitute = await this.approvalLevelRepository.findOne({
+        where: {
+          company_id: level.company_id,
+          level_order: level.level_order,
+          is_active: true,
+          id: Not(id),
+        },
+      });
+
+      if (!substitute) {
+        throw this.clientError(
+          `Cannot delete: ${pendingCount} pending request(s) at level order ${level.level_order} with no substitute`,
+          'APPROVAL_LEVEL_HAS_PENDING_REQUESTS',
+        );
+      }
+
+      await this.approvalLevelRepository.manager.transaction(async (em) => {
+        await em.update(RequestEntity, { current_approval_level_id: id }, { current_approval_level_id: substitute.id });
+        await em.update(RequestApproval, { approval_level_id: id, status: 'PENDING' }, { approval_level_id: substitute.id });
+        await em.delete(ApprovalLevel, id);
+      });
+
+      return {
+        status: true,
+        message: `ApprovalLevel ${id} deleted; ${pendingCount} request(s) reassigned to ${substitute.id}`,
+      };
+    }
+
     await this.approvalLevelRepository.delete(id);
     return { status: true, message: `ApprovalLevel ${id} deleted` };
   }

--- a/monarca/src/approval-engine/dto/approval-level-actor.dto.ts
+++ b/monarca/src/approval-engine/dto/approval-level-actor.dto.ts
@@ -5,6 +5,7 @@
  *              UpdateApprovalLevelActorDto extends Create with all fields optional.
  * Authors: DebugStudio Team
  * Last Modification: 23/04/2026 [Julio Rodríguez] Created DTOs for ApprovalLevelActor CRUD.
+ * 13/05/2026 [Julio Rodriguez] Fixed ceco_id validator from @IsUUID to @IsString (CECO ids are varchar, not UUIDs).
  */
 
 import { ApiProperty, PartialType } from '@nestjs/swagger';
@@ -52,8 +53,8 @@ export class CreateApprovalLevelActorDto {
   @IsOptional()
   selection_mode?: string;
 
-  @ApiProperty({ example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', required: false })
-  @IsUUID()
+  @ApiProperty({ example: 'TEC-001', required: false })
+  @IsString()
   @IsOptional()
   ceco_id?: string;
 

--- a/monarca/src/approval-engine/dto/approval-level.dto.ts
+++ b/monarca/src/approval-engine/dto/approval-level.dto.ts
@@ -5,8 +5,7 @@
  *              UpdateApprovalLevelDto extends Create with all fields optional.
  * Authors: DebugStudio Team
  * Last Modification made:
- * 05/05/2026 [Julio Rodriguez] company_id optional (derived from caller for company admins);
- *                              added InlineActorDto + actor field to create level and actor in one request.
+ * 13/05/2026 [Julio Rodriguez] Added ceco_id to InlineActorDto for CECO-scoped actor assignment.
  */
 
 import { ApiProperty, PartialType } from '@nestjs/swagger';
@@ -53,6 +52,11 @@ export class InlineActorDto {
   @Min(1)
   @IsOptional()
   required_count?: number;
+
+  @ApiProperty({ example: 'TEC-001', required: false })
+  @IsString()
+  @IsOptional()
+  ceco_id?: string;
 }
 
 export class CreateApprovalLevelDto {

--- a/monarca/src/requests/requests.service.ts
+++ b/monarca/src/requests/requests.service.ts
@@ -243,7 +243,11 @@ export class RequestsService {
       );
     }
 
-    const actor = level.approval_level_actors?.[0] ?? null;
+    const actors = level.approval_level_actors ?? [];
+    const actor = actors.find((a) => a.ceco_id === id_ceco)
+      ?? actors.find((a) => a.ceco_id === null)
+      ?? actors[0]
+      ?? null;
     let adminId: string | null = null;
     if (actor?.target_id) {
       adminId = actor.target_id;

--- a/monarca/src/reservations/dto/reservation.dtos.ts
+++ b/monarca/src/reservations/dto/reservation.dtos.ts
@@ -5,7 +5,8 @@
  *              reservations, and exposes the entity shape as ReservationDto.
  * Authors: Original Moncarca team
  * Last Modification made:
- * 24/04/2026 [Julio Rodriguez] Standardized validators for Swagger.
+ * 14/05/2026 [Julio Rodriguez] Added @Type(() => Number) to price field so FormData strings are
+ *                              coerced to numbers before @IsNumber() validation.
  */
 
 import { ApiProperty, PartialType, OmitType } from '@nestjs/swagger';
@@ -15,6 +16,7 @@ import {
   IsOptional,
   IsUUID,
 } from 'class-validator';
+import { Type } from 'class-transformer';
 import { Reservation } from '../entity/reservations.entity';
 
 export class CreateReservationDto {
@@ -40,6 +42,7 @@ export class CreateReservationDto {
     required: true,
   })
   @IsNumber()
+  @Type(() => Number)
   price: number;
 
   @ApiProperty({


### PR DESCRIPTION
## Summary

- Added `GET /admin/companies/:companyId/info` endpoint accessible to both company admins and system admins, so the frontend can display the company name instead of a UUID.
- Fixed `@Type(() => Number)` missing from `price` in `CreateReservationDto` — FormData sends price as a string and `@IsNumber()` always failed with 400, silently blocking reservation creation.

**Changes included:**
- `admin.service.ts` — `getCompanyInfo()` with company-scoped access check
- `admin.controller.ts` — `GET /admin/companies/:companyId/info` route (no `SystemAdminGuard`)
- `approval-engine.service.ts` — header update (cosmetic)
- `reservations/dto/reservation.dtos.ts` — `@Type(() => Number)` on `price`

## PR Targeting Checklist

- [x] This PR targets the `develop` branch (for most changes)
- [ ] This PR targets the `main` branch (ONLY for release branches or hotfixes)

> ⚠️ IMPORTANT: PRs to `main` should only come from `develop` or release branches.