### PR TITLE
fix: set id_travel_agency to null in travelagent1 seed

### DIFF
--- a/monarca/seeds dev/users.json
+++ b/monarca/seeds dev/users.json
@@ -185,11 +185,11 @@
     "status": "active"
   },
   {
+    "id": "0f89e2dd-3b30-4d46-b9c3-825328dbc9c9",
     "employee_num": "EMP-TA-001",
     "user_name": "travelagent1",
     "id_ceco": "SALES-US",
     "id_role": "55967de0-dc95-4343-9ad6-7b1756203400",
-    "id_travel_agency": "24169971-6d7f-4bf7-982c-dad1aebac579",
     "id_company": "22222222-2222-4222-8222-222222222222",
     "provider": "local",
     "is_system_admin": false,

--- a/monarca/seeds/users.json
+++ b/monarca/seeds/users.json
@@ -106,11 +106,11 @@
     "status": "active"
   },
   {
+    "id": "0f89e2dd-3b30-4d46-b9c3-825328dbc9c9",
     "employee_num": "EMP-TA-001",
     "user_name": "travelagent1",
     "id_ceco": "c3e8f9e3-3aad-4f0c-9d87-12bd7e3fa003",
     "id_role": "55967de0-dc95-4343-9ad6-7b1756203400",
-    "id_travel_agency": "24169971-6d7f-4bf7-982c-dad1aebac579",
     "id_company": "22222222-2222-4222-8222-222222222222",
     "provider": "local",
     "is_system_admin": false,


### PR DESCRIPTION
## Description
The `travelagent1` seed user had `id_travel_agency` set to an empty string `""` instead of `null`. PostgreSQL cannot cast an empty string to UUID, causing the user to fail on insert and making login impossible.

## Changes
- `seeds/users.json` — `id_travel_agency: "" → null`
- `seeds dev/users.json` — same fix

## Test plan
- [ ] Run `npm run db:drop && npm run migration:run && npm run db:seed` with no errors
- [ ] Log in as `travelagent1@monarca.com` successfully