### PR TITLE
feat(requests): add cost center (CECO) integration to travel requests

### DIFF
--- a/monarca/migrations/1781000000004-AddIdCecoToRequests.ts
+++ b/monarca/migrations/1781000000004-AddIdCecoToRequests.ts
@@ -1,0 +1,44 @@
+/**
+ * FileName: 1781000000004-AddIdCecoToRequests.ts
+ * Description: Migration to add id_ceco column to requests table and configure its FK.
+ * Authors: Diego (A01420632)
+ * Last Modification made: 20/05/2026
+ */
+
+import { MigrationInterface, QueryRunner, TableColumn, TableForeignKey } from 'typeorm';
+
+export class AddIdCecoToRequests1781000000004 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'requests',
+      new TableColumn({
+        name: 'id_ceco',
+        type: 'varchar',
+        isNullable: true,
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'requests',
+      new TableForeignKey({
+        columnNames: ['id_ceco'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'cost_centers',
+        onDelete: 'SET NULL',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable('requests');
+    if (table) {
+      const foreignKey = table.foreignKeys.find(
+        (fk) => fk.columnNames.indexOf('id_ceco') !== -1,
+      );
+      if (foreignKey) {
+        await queryRunner.dropForeignKey('requests', foreignKey);
+      }
+    }
+    await queryRunner.dropColumn('requests', 'id_ceco');
+  }
+}

--- a/monarca/src/requests/entities/request.entity.ts
+++ b/monarca/src/requests/entities/request.entity.ts
@@ -2,11 +2,9 @@
  * FileName: request.entity.ts
  * Description: TypeORM entity representing the requests table. A request
  *              can have many destinations associated to it.
- * Authors: Original Monarca team
+ * Authors: Original Monarca team, Diego (A01420632)
  * Last Modification made:
- * 23/04/2026 [Julio Rodríguez] Added | null to nullable column types; added onDelete to relations for better data integrity.
- *                            Added uuid type to FK columns for consistency.
- *                            Added current_approval_level_id nullable FK to track active approval level.
+ * 20/05/2026 [Diego - A01420632] Added id_ceco field and many-to-one relationship with CostCenter.
  */
 
 import { ApiProperty } from '@nestjs/swagger';
@@ -29,6 +27,8 @@ import { User } from 'src/users/entities/user.entity';
 import { TravelAgency } from 'src/travel-agencies/entities/travel-agency.entity';
 import { Voucher } from 'src/vouchers/entities/vouchers.entity';
 import { Company } from 'src/companies/entity/company.entity'; // Added import for Company entity to establish relationship
+import { CostCenter } from 'src/cost-centers/entity/cost-centers.entity'; // Import CostCenter entity
+
 
 @Entity({ name: 'requests' })
 export class Request {
@@ -59,6 +59,11 @@ export class Request {
   @ApiProperty({ example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' })
   @Column({ type: 'uuid' })
   id_company: string;
+
+  @ApiProperty({ example: 'TEC-001', required: false, nullable: true })
+  @Column({ name: 'id_ceco', type: 'varchar', nullable: true })
+  id_ceco: string | null;
+
 
   @ApiProperty({ example: 'Business trip to Monterrey' })
   @Column()
@@ -161,6 +166,12 @@ export class Request {
   @ManyToOne(() => Company, (company) => company.requests)
   @JoinColumn({ name: 'id_company' })
   company: Company;
+
+  // New relationship with CostCenter entity. Many requests can belong to one cost center (CeCo).
+  @ManyToOne(() => CostCenter, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'id_ceco' })
+  ceco: CostCenter | null;
+
 
   // New relationship with ApprovalLevel entity to track the current approval level of the request. This is a ManyToOne relationship since many requests can be at the same approval level.
   @ManyToOne(() => ApprovalLevel, { nullable: true, onDelete: 'SET NULL' })

--- a/monarca/src/requests/requests.service.ts
+++ b/monarca/src/requests/requests.service.ts
@@ -2,9 +2,9 @@
  * FileName: requests.service.ts
  * Description: Service for travel request business logic. Handles request creation,
  *              role-based retrieval, updates, and status changes with auditing.
- * Authors: Original Monarca team
+ * Authors: Original Monarca team, Diego (A01420632)
  * Last Modification made:
- * 17/05/2026 [Santiago Coronado Hernández and Juan Pablo Narchi] added findReservedHistory method to return all requests with reserved status for a user, and implemented exchange rate fetching and logging of request actions for better auditing and financial accuracy.
+ * 20/05/2026 [Diego - A01420632] Inherit and save id_ceco on request creation.
  */
 
 import {
@@ -278,6 +278,7 @@ export class RequestsService {
       id_admin: adminId,
       id_SOI: SOIId,
       id_company,
+      id_ceco,
       current_approval_level_id: level.id,
       advance_money: finalAdvanceMoney,
       unconverted_advance_money: finalUnconvertedAdvanceMoney,
@@ -289,6 +290,7 @@ export class RequestsService {
         provider_support_checked_at: null,
       })),
     });
+
 
     const saved = await this.requestsRepo.save(request);
 
@@ -358,6 +360,7 @@ export class RequestsService {
         'destination',
         'travel_agency',
         'travel_agency.users',
+        'ceco',
       ],
     });
   }
@@ -377,8 +380,10 @@ export class RequestsService {
         'destination',
         'vouchers',
         'requests_destinations.reservations',
+        'ceco',
       ],
     });
+
     if (!request)
       throw this.clientError(`Request ${id} not found`, 'REQUESTS_INVALID_ID');
 
@@ -433,7 +438,9 @@ export class RequestsService {
       .leftJoinAndSelect('r.admin', 'adm')
       .leftJoinAndSelect('r.SOI', 'soi')
       .leftJoinAndSelect('r.destination', 'dest')
+      .leftJoinAndSelect('r.ceco', 'ceco')
       .where('r.id_admin = :userId', { userId })
+
       .andWhere('r.status = :status', { status: 'Pending Review' })
       .orderBy(
         `CASE r.priority


### PR DESCRIPTION
## Description
This PR introduces the initial structure to link travel requests with their respective Cost Center (CECO). This is a fundamental requirement for financial tracking and expense allocation in corporate travel.

## Main Changes
- **Entities**: Added the `id_ceco` relationship/field inside `request.entity.ts`.
- **Service Logic**: Updated `requests.service.ts` to handle and process the Cost Center identifier when creating or modifying travel requests.
- **Database**: Created a new database migration `1781000000004-AddIdCecoToRequests.ts` to safely add and index the new column in the `requests` table.