### PR TITLE
docs(windows): added conf scripts for https and updated README-WINDOWS

### DIFF
--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -124,13 +124,40 @@ npm run setup
 npm run dev
 ```
 
-### G) Verify services
+### G) Enable Local HTTPS (Highly Recommended)
 
+To run the application locally under HTTPS (matching production, securing cookies, and enabling secure browser features), use the automated setup script.
+
+1. Open **PowerShell as Administrator** (required to register the Root Certificate Authority locally).
+2. Navigate to the root directory where you cloned the repositories (e.g., `D:\Escritorio\TEC\Ditta`).
+3. Allow script execution for the session and run the configurator:
+   ```powershell
+   Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+   .\setup-https.ps1
+   ```
+
+*What this script does:*
+- Checks and installs `mkcert` (the standard local SSL utility) via `winget`.
+- Installs the local Root CA in your Windows trust store so your browser marks localhost as secure.
+- Creates `certs/` folders in both the Frontend and Backend repositories.
+- Generates locally-trusted certificates (`frontend.pem`, `frontend-key.pem`, `backend.pem`, `backend-key.pem`).
+- Automatically transitions all your local `.env` variables from `http://` to `https://`.
+
+4. Restart your active development servers (`npm run dev`) so they load the new certs.
+
+### H) Verify services
+
+**If running under standard HTTP (default):**
 - Frontend: `http://localhost:5173`
-- Backend: `http://localhost:3000`
-- Swagger: `http://localhost:3000/api`
+- Backend: `http://localhost:3002` (or `3000` depending on your `.env` config)
+- Swagger: `http://localhost:3002/api`
 
-### H) Common Windows issues
+**If running under HTTPS (after running the script):**
+- Frontend: `https://localhost:5173`
+- Backend: `https://localhost:3002` (or `3000` depending on your `.env` config)
+- Swagger: `https://localhost:3002/api`
+
+### I) Common Windows issues
 
 1. `ENOENT: Could not read package.json (D:\\package.json)`
 

--- a/setup-https.ps1
+++ b/setup-https.ps1
@@ -1,0 +1,91 @@
+# HTTPS Configuration Script for Monarca (Windows)
+# Run in PowerShell as Administrator
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "=============================================" -ForegroundColor Cyan
+Write-Host "  Local HTTPS Configurator for Windows       " -ForegroundColor Cyan
+Write-Host "=============================================" -ForegroundColor Cyan
+
+# 1. Verify/Install mkcert
+if (!(Get-Command mkcert -ErrorAction SilentlyContinue)) {
+    Write-Host "[*] mkcert is not installed. Installing it via winget..." -ForegroundColor Yellow
+    winget install FiloSottile.mkcert --accept-source-agreements --accept-package-agreements
+    
+    # Try to refresh current session PATH environment variable
+    $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+    
+    if (!(Get-Command mkcert -ErrorAction SilentlyContinue)) {
+        Write-Host "[!] mkcert was installed but is not yet in the PATH of this terminal." -ForegroundColor Red
+        Write-Host "[!] Please open a NEW PowerShell window as ADMINISTRATOR and run this script again." -ForegroundColor Yellow
+        exit
+    }
+} else {
+    Write-Host "[OK] mkcert is already installed." -ForegroundColor Green
+}
+
+# 2. Install the Root Certificate Authority (CA) in the Windows Trust Store
+Write-Host "[*] Installing local Certificate Authority (CA)..." -ForegroundColor Yellow
+& mkcert -install
+
+# 3. Create certs directories if they do not exist
+$frontendCertsDir = Join-Path (Get-Item .).FullName "Frontend\certs"
+$backendCertsDir = Join-Path (Get-Item .).FullName "Backend\monarca\certs"
+
+if (!(Test-Path $frontendCertsDir)) {
+    New-Item -ItemType Directory -Path $frontendCertsDir -Force | Out-Null
+    Write-Host "[OK] Frontend certs folder created." -ForegroundColor Green
+}
+if (!(Test-Path $backendCertsDir)) {
+    New-Item -ItemType Directory -Path $backendCertsDir -Force | Out-Null
+    Write-Host "[OK] Backend certs folder created." -ForegroundColor Green
+}
+
+# 4. Generate local certificates for localhost and 127.0.0.1
+Write-Host "[*] Generating certificates for Frontend..." -ForegroundColor Yellow
+Push-Location "Frontend\certs"
+& mkcert -key-file frontend-key.pem -cert-file frontend.pem localhost 127.0.0.1
+Pop-Location
+Write-Host "[OK] Frontend certificates generated successfully." -ForegroundColor Green
+
+Write-Host "[*] Generating certificates for Backend..." -ForegroundColor Yellow
+Push-Location "Backend\monarca\certs"
+& mkcert -key-file backend-key.pem -cert-file backend.pem localhost 127.0.0.1
+Pop-Location
+Write-Host "[OK] Backend certificates generated successfully." -ForegroundColor Green
+
+# 5. Modify .env files to use HTTPS
+Write-Host "[*] Configuring .env files to use HTTPS..." -ForegroundColor Yellow
+
+$frontendEnvPath = "Frontend\.env"
+$backendEnvPath = "Backend\monarca\.env"
+
+# Frontend .env
+if (Test-Path $frontendEnvPath) {
+    $content = Get-Content $frontendEnvPath
+    $updated = $content -replace "http://localhost:3000", "https://localhost:3000"
+    $updated = $updated -replace "http://localhost:3002", "https://localhost:3002"
+    $updated | Set-Content $frontendEnvPath
+    Write-Host "[OK] Frontend .env updated to HTTPS." -ForegroundColor Green
+} else {
+    Write-Host "[!] Frontend .env file not found." -ForegroundColor Red
+}
+
+# Backend .env
+if (Test-Path $backendEnvPath) {
+    $content = Get-Content $backendEnvPath
+    $updated = $content -replace "http://localhost:3000", "https://localhost:3000"
+    $updated = $updated -replace "http://localhost:3002", "https://localhost:3002"
+    $updated = $updated -replace "http://localhost:5173", "https://localhost:5173"
+    $updated | Set-Content $backendEnvPath
+    Write-Host "[OK] Backend .env updated to HTTPS." -ForegroundColor Green
+} else {
+    Write-Host "[!] Backend .env file not found." -ForegroundColor Red
+}
+
+Write-Host "=============================================" -ForegroundColor Green
+Write-Host "  HTTPS Configuration Completed!             " -ForegroundColor Green
+Write-Host "  Start your services again:                 " -ForegroundColor Green
+Write-Host "  - Frontend: https://localhost:5173         " -ForegroundColor Green
+Write-Host "  - Backend: https://localhost:3000          " -ForegroundColor Green
+Write-Host "=============================================" -ForegroundColor Green

--- a/setup-https.sh
+++ b/setup-https.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# HTTPS Configuration Script for Monarca (macOS)
+# Run in terminal from the project root directory
+
+set -e
+
+echo "============================================="
+echo "  Local HTTPS Configurator for macOS         "
+echo "============================================="
+
+# 1. Verify/Install Homebrew and mkcert
+if ! command -v mkcert &> /dev/null; then
+    echo "[*] mkcert is not installed."
+    if ! command -v brew &> /dev/null; then
+        echo "[!] Homebrew is not installed. Please install Homebrew first: https://brew.sh/"
+        exit 1
+    fi
+    echo "[*] Installing mkcert with Homebrew..."
+    brew install mkcert
+    brew install nss # For Firefox support
+fi
+
+# 2. Install Root CA in the macOS Keychain
+echo "[*] Installing local Certificate Authority (CA)..."
+mkcert -install
+
+# 3. Create certs directories if they do not exist
+frontend_certs_dir="Frontend/certs"
+backend_certs_dir="Backend/monarca/certs"
+
+mkdir -p "$frontend_certs_dir"
+mkdir -p "$backend_certs_dir"
+echo "[OK] Certificate folders prepared."
+
+# 4. Generate local certificates for localhost and 127.0.0.1
+echo "[*] Generating certificates for Frontend..."
+cd "$frontend_certs_dir"
+mkcert -key-file frontend-key.pem -cert-file frontend.pem localhost 127.0.0.1
+cd - > /dev/null
+echo "[OK] Frontend certificates generated successfully."
+
+echo "[*] Generating certificates for Backend..."
+cd "$backend_certs_dir"
+mkcert -key-file backend-key.pem -cert-file backend.pem localhost 127.0.0.1
+cd - > /dev/null
+echo "[OK] Backend certificates generated successfully."
+
+# 5. Modify .env files to use HTTPS
+echo "[*] Configuring .env files to use HTTPS..."
+
+frontend_env="Frontend/.env"
+backend_env="Backend/monarca/.env"
+
+# Frontend .env
+if [ -f "$frontend_env" ]; then
+    # Use macOS compatible sed (sed -i '')
+    sed -i '' 's|http://localhost:3000|https://localhost:3000|g' "$frontend_env"
+    sed -i '' 's|http://localhost:3002|https://localhost:3002|g' "$frontend_env"
+    echo "[OK] Frontend .env updated to HTTPS."
+else
+    echo "[!] Frontend .env file not found."
+fi
+
+# Backend .env
+if [ -f "$backend_env" ]; then
+    sed -i '' 's|http://localhost:3000|https://localhost:3000|g' "$backend_env"
+    sed -i '' 's|http://localhost:3002|https://localhost:3002|g' "$backend_env"
+    sed -i '' 's|http://localhost:5173|https://localhost:5173|g' "$backend_env"
+    echo "[OK] Backend .env updated to HTTPS."
+else
+    echo "[!] Backend .env file not found."
+fi
+
+echo "============================================="
+echo "  HTTPS Configuration Completed!             "
+echo "  Start your services again:                 "
+echo "  - Frontend: https://localhost:5173         "
+echo "  - Backend: https://localhost:3000          "
+echo "============================================="


### PR DESCRIPTION
# What
- Added an automated PowerShell script (setup-https.ps1) for Windows to check/install mkcert, install the local Root CA, generate SSL certificates, and update local .env files.
- Added an automated Bash script (setup-https.sh) for macOS to streamline local HTTPS setup using Homebrew.
- Updated the Windows developer guide (README-WINDOWS.md) to document the new local HTTPS setup and list both HTTP/HTTPS endpoints under the verified services section.

# Why
To support local HTTPS across both macOS and Windows environments. This ensures local environment parity with production, secures browser authentication cookies (Secure/SameSite), and enables advanced web APIs (Secure Contexts) to run natively in local development.

# How to test (optional)
1. Run the setup script from the root of the project (.\Backend\setup-https.ps1 on Windows or ./Backend/setup-https.sh on macOS).
2. Verify that the local CA is successfully installed in the system trust store and that local .env files (Frontend and Backend) are updated to HTTPS.
3. Start the dev servers (npm run dev) and verify that services run securely on https://localhost:5173 and https://localhost:3000.

## IMPORTANT NOTES:
1. Take into account that this script has to be run in the root folder where the two repositories exist.
2. The two repositories taken are named Backend and Frontend, but yours may be named differently, adjust accordingly.
3. However, if you already ran the script, just copy the certs folder and paste them in Backend/monarca (for Backend) and Frontend (for Frontend repository). This should fix any errors.
