### PR TITLE
test: add cost center and request validation coverage

### DIFF
--- a/monarca/src/cost-centers/cost-centers.service.spec.ts
+++ b/monarca/src/cost-centers/cost-centers.service.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * FileName: cost-centers.service.spec.ts
+ * Description: Test suite for CostCentersService. Contains unit tests to validate cost center creation, retrieval, and deletion logic, including company association validation and duplicate ID checks. Ensures that business rules are enforced and data integrity is maintained.
+ * Authors: DebugStudio Team
+ * Last Modification made: 
+ * 31/05/2026 [Jin Sik Yoon] Implemented unit tests for CostCentersService covering cost center creation, retrieval, and deletion scenarios.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BadRequestException } from '@nestjs/common';
+
+import { CostCentersService } from './cost-centers.service';
+import { CostCenter } from './entity/cost-centers.entity';
+
+describe('CostCentersService', () => {
+  let service: CostCentersService;
+
+  const mockRepo = {
+    findOneBy: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CostCentersService,
+        {
+          provide: getRepositoryToken(CostCenter),
+          useValue: mockRepo,
+        },
+      ],
+    }).compile();
+
+    service = module.get<CostCentersService>(CostCentersService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should create a cost center', async () => {
+    const dto = {
+      id: 'TEC-001',
+      name: 'Finance',
+      id_company: 'company-1',
+    };
+
+    mockRepo.findOneBy.mockResolvedValue(null);
+    mockRepo.create.mockReturnValue(dto);
+    mockRepo.save.mockResolvedValue(dto);
+
+    const result = await service.create('company-1', dto);
+
+    expect(result.id).toBe('TEC-001');
+    expect(mockRepo.save).toHaveBeenCalled();
+  });
+
+  it('should reject company mismatch', async () => {
+    const dto = {
+      id: 'TEC-001',
+      name: 'Finance',
+      id_company: 'different-company',
+    };
+
+    await expect(
+      service.create('company-1', dto),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('should reject duplicate cost center id', async () => {
+    mockRepo.findOneBy.mockResolvedValue({
+      id: 'TEC-001',
+    });
+
+    const dto = {
+      id: 'TEC-001',
+      name: 'Finance',
+      id_company: 'company-1',
+    };
+
+    await expect(
+      service.create('company-1', dto),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('should find a cost center', async () => {
+    mockRepo.findOneBy.mockResolvedValue({
+      id: 'TEC-001',
+      name: 'Finance',
+      id_company: 'company-1',
+    });
+
+    const result = await service.findOne(
+      'company-1',
+      'TEC-001',
+    );
+
+    expect(result.id).toBe('TEC-001');
+  });
+
+  it('should throw when cost center does not exist', async () => {
+    mockRepo.findOneBy.mockResolvedValue(null);
+
+    await expect(
+      service.findOne('company-1', 'INVALID'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('should remove a cost center', async () => {
+    mockRepo.findOneBy.mockResolvedValue({
+      id: 'TEC-001',
+      id_company: 'company-1',
+    });
+
+    mockRepo.delete.mockResolvedValue({});
+
+    const result = await service.remove(
+      'company-1',
+      'TEC-001',
+    );
+
+    expect(result.status).toBe(true);
+  });
+});

--- a/monarca/src/requests/requests.service.spec.ts
+++ b/monarca/src/requests/requests.service.spec.ts
@@ -1,3 +1,11 @@
+/**
+ * FileName: requests.service.spec.ts
+ * Description: Test suite for RequestsService. Contains unit tests to validate request creation logic, including requester cost center validation and Banxico rate fetching. Ensures that business rules are enforced and external API interactions are handled correctly.
+ * Authors: DebugStudio Team
+ * Last Modification made: 
+ * 31/05/2026 [Jin Sik Yoon] Implemented unit tests for RequestsService covering request creation and Banxico rate fetching scenarios.
+ */
+
 import { Test, TestingModule } from '@nestjs/testing';
 import { RequestsService } from './requests.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
@@ -6,6 +14,9 @@ import { UserChecks } from 'src/users/user.checks.service';
 import { DestinationsChecks } from 'src/destinations/destinations.checks';
 import { NotificationsService } from 'src/notifications/notifications.service';
 import { DataSource } from 'typeorm';
+import { ApprovalLevel } from 'src/approval-engine/entities/approval-level.entity';
+import { RequestApproval } from 'src/approval-engine/entities/request-approval.entity';
+import { UserLogsService } from 'src/user-logs/user-logs.service';
 
 describe('RequestsService', () => {
   let service: RequestsService;
@@ -19,16 +30,32 @@ describe('RequestsService', () => {
           useValue: {},
         },
         {
+          provide: getRepositoryToken(ApprovalLevel),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(RequestApproval),
+          useValue: {},
+        },
+        {
           provide: UserChecks,
           useValue: {},
         },
         {
           provide: DestinationsChecks,
-          useValue: {},
+          useValue: {
+            isValid: jest.fn().mockResolvedValue(true),
+          },
         },
         {
           provide: NotificationsService,
           useValue: {},
+        },
+        {
+          provide: UserLogsService,
+          useValue: {
+            create: jest.fn(),
+          },
         },
         {
           provide: DataSource,
@@ -44,6 +71,32 @@ describe('RequestsService', () => {
     expect(service).toBeDefined();
   });
 
+  it('should reject request creation when requester has no cost center', async () => {
+    const req: any = {
+      sessionInfo: { id: 'requester-id' },
+      userInfo: {
+        id_company: 'company-id',
+        id_ceco: null,
+      },
+      ip: '127.0.0.1',
+    };
+
+    const data: any = {
+      id_origin_city: 'origin-city-id',
+      requests_destinations: [
+        {
+          id_destination: 'destination-city-id',
+        },
+      ],
+    };
+
+    await expect(service.create(req, data)).rejects.toMatchObject({
+      response: {
+        code: 'REQUESTS_REQUESTER_CECO_REQUIRED',
+      },
+    });
+  });
+
   describe('fetchBanxicoRate', () => {
     let originalEnv: NodeJS.ProcessEnv;
     let originalFetch: typeof fetch;
@@ -56,7 +109,7 @@ describe('RequestsService', () => {
     });
 
     afterEach(() => {
-      process.env = originalEnv;
+      process.env = { ...originalEnv };
       global.fetch = originalFetch;
       jest.restoreAllMocks();
     });


### PR DESCRIPTION
Added test coverage for:
- Request creation validation when user has no cost center
- Cost center creation
- Duplicate cost center validation
- Company mismatch validation
- Cost center retrieval
- Cost center deletion