### PR TITLE
feat(requests): make destination details field optional

### DIFF
--- a/monarca/src/requests/dto/create-request.dto.ts
+++ b/monarca/src/requests/dto/create-request.dto.ts
@@ -83,9 +83,11 @@ export class RequestDestinationtDto {
   @ApiProperty({
     description: 'Additional details or requirements for this destination',
     example: 'Hotel near downtown',
+    required: false,
   })
+  @IsOptional()
   @IsString()
-  details: string;
+  details?: string;
 }
 
 export class CreateRequestDto {


### PR DESCRIPTION
## Summary
- `details` field in `RequestDestinationtDto` is now optional (`@IsOptional()`)
- Aligns with the frontend change that removes the required validation on the details input

## Test plan
- [ ] Create a travel request without filling the details field on a destination and verify it saves correctly
- [ ] Create a travel request with details filled and verify it still saves correctly

> Test alongside frontend PR: Equipo2-TC3004B-102/Monarca_Frontend#120